### PR TITLE
hoping to remove need for z-order'ing

### DIFF
--- a/css/dev.css
+++ b/css/dev.css
@@ -5,14 +5,12 @@
 
 .ui-rangeSlider{
 	height:22px;
-	z-index:1;
 }
 
 .ui-rangeSlider .ui-rangeSlider-innerBar{
 	height:16px;
 	margin:3px 6px;
 	background:#DDD;
-	z-index:2;
 }
 
 .ui-rangeSlider .ui-rangeSlider-handle{
@@ -21,7 +19,6 @@
 	background:#AAA;
 	background:rgba(100,100,100, 0.3);
 	cursor:col-resize;
-	z-index:4;
 }
 
 .ui-rangeSlider .ui-rangeSlider-bar{
@@ -32,7 +29,6 @@
 	cursor:move;
 	cursor:grab;
 	cursor: -moz-grab;
-	z-index:3;
 }
 
 .ui-rangeSlider .ui-rangeSlider-bar.ui-draggable-dragging{

--- a/jQRangeSlider.js
+++ b/jQRangeSlider.js
@@ -96,10 +96,10 @@
 			$(document).bind("mouseup", $.proxy(this._stopScroll, this));
 
 			this.container
-				.append(this.leftHandle)
-				.append(this.rightHandle)
 				.append(this.innerBar)
-				.append(this.bar);
+				.append(this.bar)
+				.append(this.leftHandle)
+			    .append(this.rightHandle);
 
 			this.element
 				.append(this.container)


### PR DESCRIPTION
Hi,

I ran into z-order issues in my app where I have a pop-up menu rendering over the slider. With the current slider design the slider will render on top of my menu unless I set a z-order on my menu. However after looking at the slider code it seems that just changing the order that elements of the slider are added will remove the need for any z-order settings in the slider's CSS. It's a small change and seems to work so hoping you'll agree, and will make this change part of your version.

Thanks,

-David 
