### PR TITLE
jQRangeSlider also depends on jQuery UI mouse

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -18,6 +18,7 @@ Dependencies
 + jQuery
 + jQuery UI core
 + jQuery UI widget
++ jQuery UI mouse
 + jQuery Mousewheel plugin by Brandon Aaron (optional, needed for scrolling or zooming)
 
 


### PR DESCRIPTION
Instead of using the provided `jquery-ui-1.8.16.custom.min.js` file, I'm using my own custom jQuery UI build. In doing so, I realized that jQRangeSlider also expects jQuery UI mouse to be available. I've added this to the Readme, but would you mind also adding this to the documentation?
