### PR TITLE
Added required version of JQuery-UI to docs

### DIFF
--- a/History.md
+++ b/History.md
@@ -5,7 +5,7 @@ jQRangeSlider
 	* Fixed #141: userValuesChanged event not fired when user edits input value
 	* Fixed #142: Labels don't show up the first time after a programmatically value change
 	* Fixed #143: Changing formatter causes labels to disappear
-    * JQuery-UI 1.10.x now required
+    * JQuery-UI 1.9 or later now required
 * 5.4.0: 2013-09-16
 	* Fixed #128: Using the mouse wheel changes the values, even if slider is disabled
 	* Fixed #130: Labels don't disappear when values changed in code

--- a/Readme.md
+++ b/Readme.md
@@ -16,7 +16,7 @@ License : Dual license GPL v3 and MIT
 Dependencies
 ------------
 + jQuery
-+ jQuery UI core (1.10.x)
++ jQuery UI core (1.9 or later)
 + jQuery UI widget
 + jQuery UI mouse
 + jQuery Mousewheel plugin by Brandon Aaron (optional, needed for scrolling or zooming)


### PR DESCRIPTION
When updating to latest jQRangeSlider (5.5.0) my code broke. I found moving to JQuery-UI 1.10.3 (as used in the latest demos) fixed it. Some experimentation today shows 1.9.2 also works.
