### PR TITLE
Fix whitespace issues

### DIFF
--- a/jQDateRangeSlider.js
+++ b/jQDateRangeSlider.js
@@ -74,7 +74,7 @@
 		_getFormatter: function(){
 			var formatter = this.options.formatter;
 
-			if (this.options.formatter === false || this.options.formatter === null){
+			if (this.options.formatter === false || this.options.formatter === null){
 				formatter = this._defaultFormatter;
 			}
 

--- a/jQEditRangeSliderLabel.js
+++ b/jQEditRangeSliderLabel.js
@@ -109,7 +109,7 @@
 	},
 
 	_setTypeOption: function(value){
-		if ((value === "text" || value === "number") && this.options.type !== value){
+		if ((value === "text" || value === "number") && this.options.type !== value){
 			this._destroyInput();
 			this.options.type = value;
 			this._createInput();

--- a/jQRangeSlider.js
+++ b/jQRangeSlider.js
@@ -507,7 +507,7 @@
 		},
 
 		_getFormatter: function(){
-			if (this.options.formatter === false || this.options.formatter === null){
+			if (this.options.formatter === false || this.options.formatter === null){
 				return this._defaultFormatter;
 			}
 
@@ -651,7 +651,7 @@
 		values: function(min, max){
 			var val;
 
-			if (typeof min !== "undefined" && typeof max !== "undefined"){
+			if (typeof min !== "undefined" && typeof max !== "undefined"){
 				if (!this._initialized){
 					this._values.min = min;
 					this._values.max = max;

--- a/jQRangeSliderBar.js
+++ b/jQRangeSliderBar.js
@@ -102,7 +102,7 @@
 		},
 
 		_setWheelModeOption: function(value){
-			if (value === null || value === false || value === "zoom" || value === "scroll"){
+			if (value === null || value === false || value === "zoom" || value === "scroll"){
 				if (this.options.wheelMode !== value){
 					this.element.parent().unbind("mousewheel.bar");
 				}
@@ -469,7 +469,7 @@
 		},
 
 		zoomIn: function(quantity){
-			quantity = quantity || 1;
+			quantity = quantity || 1;
 
 			if (quantity < 0){
 				return this.zoomOut(-quantity);

--- a/jQRangeSliderHandle.js
+++ b/jQRangeSliderHandle.js
@@ -91,7 +91,7 @@
 		_initElement: function(){
 			$.ui.rangeSliderDraggable.prototype._initElement.apply(this);
 			
-			if (this.cache.parent.width === 0 || this.cache.parent.width === null){
+			if (this.cache.parent.width === 0 || this.cache.parent.width === null){
 				setTimeout($.proxy(this._initElementIfNotDestroyed, this), 500);
 			}else{
 				this._position(this._value);

--- a/jQRangeSliderLabel.js
+++ b/jQRangeSliderLabel.js
@@ -86,7 +86,7 @@
 		_setOption: function(key, value){
 			if (key === "show"){
 				this._updateShowOption(value);
-			} else if (key === "durationIn" || key === "durationOut" || key === "delayOut"){
+			} else if (key === "durationIn" || key === "durationOut" || key === "delayOut"){
 				this._updateDurations(key, value);
 			}
 
@@ -403,7 +403,7 @@
 		}
 
 		this.ShowIfNecessary = function(){
-			if (this.options.show === "show" || this.moving || !this.initialized || this.updating) return;
+			if (this.options.show === "show" || this.moving || !this.initialized || this.updating) return;
 
 			this.label1.stop(true, true).fadeIn(this.options.durationIn || 0);
 			this.label2.stop(true, true).fadeIn(this.options.durationIn || 0);

--- a/tests/unit/rulerTests.js
+++ b/tests/unit/rulerTests.js
@@ -138,7 +138,7 @@
 			ruled.ruler({
 				min: 0,
 				max: 20,
-				scales: [shifted]
+				scales: [shifted]
 			});
 
 		},


### PR DESCRIPTION
In the process of prototyping a date slider UI I locally installed jQRangeSlider today via Twitter Bower; I had previously given it a [quick shot on JSFiddle](http://jsfiddle.net/vBLPv/) referencing the unminified, unconcatenated assets I found at [ghusse.github.io/jQRangeSlider/stable](http://ghusse.github.io/jQRangeSlider/stable) (e. g. [jQRangeSlider.js](http://ghusse.github.io/jQRangeSlider/stable/jQRangeSlider.js)).
While everything went fine on JSFiddle, I ran into errors when trying to replicate the JSFiddle locally, again using the unminified, unpackaged assets I installed via Twitter Bower:

![console](https://cloud.githubusercontent.com/assets/21834/3689090/e679682a-133c-11e4-8e3b-f5809667a8da.png)

After a quick inspection it turned out that a bunch of "non-breaking white space unicode characters" (a quick search lead me to believe that the "Â" character visible in the Chrome Developer Tools might be such a thing ;)) caused the problem (both on my Mac and Windows dev boxes):

![blank](https://cloud.githubusercontent.com/assets/21834/3689247/5981b3d0-133e-11e4-965a-41a65b99e9b8.png)

I searched all occurences of said character in the jQRangeSlider repository, replaced them with "regular" whitespace – and now things are working fine again.
