### PR TITLE
Update jQDateRangeSliderHandle.js

### DIFF
--- a/jQDateRangeSliderHandle.js
+++ b/jQDateRangeSliderHandle.js
@@ -58,8 +58,8 @@
 				return;
 			}
 
-			var minDate = new Date(this.options.bounds.min),
-				maxDate = new Date(this.options.bounds.max),
+			var minDate = new Date(this.options.bounds.min.valueOf()),
+				maxDate = new Date(this.options.bounds.max.valueOf()),
 				stepDate = minDate,
 				i = 0,
 				previous = new Date();


### PR DESCRIPTION
Using negative Dates (BC), e.g. new Date(-400,0,1) as bounds crashed the whole slider in Firefox.
In Firefox the following will create an "Invalid Date": var a = new Date(-400,0,1); var b = new Date(a);
So to clone the Date Object it is safer to use its valueOf than the Date-object itself.
