### PR TITLE
Update jQDateRangeSlider.js

### DIFF
--- a/jQDateRangeSlider.js
+++ b/jQDateRangeSlider.js
@@ -36,8 +36,8 @@
 
 		_setRulerParameters: function(){
 			this.ruler.ruler({
-				min: new Date(this.options.bounds.min),
-				max: new Date(this.options.bounds.max),
+				min: new Date(this.options.bounds.min.valueOf()),
+				max: new Date(this.options.bounds.max.valueOf()),
 				scales: this.options.scales
 			});
 		},


### PR DESCRIPTION
Ruler isn't working with negative Dates (eg. new Date (-400,0,1)) in Firefox.
Creating a new Date with a negative Date as parameter causes an "Invalid Date" in Firefox.
Therfore I changed the parmeter to use valueOf().
