### PR TITLE
fixed touch events for jquery-ui.1.11.x

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,5 +1,7 @@
 jQRangeSlider
 -------------
+* 5.7.1: 2015-01-20
+    * Fixed #174: Touch and jquery-ui 1.11.0 (not working)
 * 5.7.0: 2014-03-18
 	* Enhancement #154: 
 		* Introduced a new option "symmetricPositionning" for a different way of positionning handles

--- a/jQRangeSlider.jquery.json
+++ b/jQRangeSlider.jquery.json
@@ -1,6 +1,6 @@
 {
 	"name": "jQRangeSlider",
-	"version": "5.7.0",
+	"version": "5.7.1",
 	"title": "jQRangeSlider",
 	"description": "A javascript slider selector that supports dates",
 	"author": {

--- a/jQRangeSliderMouseTouch.js
+++ b/jQRangeSliderMouseTouch.js
@@ -27,7 +27,7 @@
 			$(document)
 				.unbind('touchmove.' + this.widgetName, this._touchMoveDelegate)
 				.unbind('touchend.' + this.widgetName, this._touchEndDelegate);
-			
+
 			$.ui.mouse.prototype._mouseDestroy.apply(this);
 		},
 
@@ -41,7 +41,7 @@
 
 		destroy: function(){
 			this._mouseDestroy();
-			
+
 			$.ui.mouse.prototype.destroy.apply(this);
 
 			this._mouseInit = null;
@@ -114,6 +114,8 @@
 
 			event.pageX = touch.pageX;
 			event.pageY = touch.pageY;
+
+			event.which = 1; // [~] fixes touch events for jquery-ui.1.11.x.mouse
 		}
 	});
 }(jQuery));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jQRangeSlider",
-  "version": "5.7.0",
+  "version": "5.7.1",
   "scripts": {
     "test": "grunt ci --verbose"
   },


### PR DESCRIPTION
jquery-ui.1.11 introduced a test that breaks touch events for the slider (at http://code.jquery.com/ui/1.11.0/jquery-ui.js lines 960-961). This patch fixes the issue