### PR TITLE
Prevent destroyed slider from running its resize handler.

### DIFF
--- a/jQRangeSlider.js
+++ b/jQRangeSlider.js
@@ -725,10 +725,12 @@
 		 * Resize
 		 */
 		resize: function(){
-			this._initWidth();
-			this._leftHandle("update");
-			this._rightHandle("update");
-			this._bar("update");
+			if (this.container){
+				this._initWidth();
+				this._leftHandle("update");
+				this._rightHandle("update");
+				this._bar("update");
+			}
 		},
 
 		/*


### PR DESCRIPTION
Under some circumstances I see error reports with the latest jqRangeSlider showing a crash in _initWidth (invoked by resize) because this.container is null.  This should not happen because container is only nulled during destroy, which also removes the resize handler.  I guess that the resize event is already in progress at some level, and continues regardless.  The stack report does go far enough to tell.