### PR TITLE
bar handles: add deactivate option

### DIFF
--- a/jQRangeSlider.js
+++ b/jQRangeSlider.js
@@ -22,6 +22,7 @@
 			durationIn: 0,
 			durationOut: 400,
 			delayOut: 200,
+			barHandles: true,
 			range: {min: false, max: false},
 			step: false,
 			scales: false,
@@ -100,6 +101,7 @@
 			this._setScalesOption(key, value);
 			this._setEnabledOption(key, value);
 			this._setPositionningOption(key, value);
+			this._setBarHandlesOption(key, value);
 		},
 
 		_validProperty: function(object, name, defaultValue){
@@ -201,6 +203,14 @@
 			}
 		},
 
+		_setBarHandlesOption: function(key, value){
+
+			if (key === "barHandles" && (value === true || value === false) && value !== this.options.barHandles){
+				this._rightHandle("option", key, value);
+				this.options[key] = this._leftHandle("option", key, value);
+			}
+		},
+
 		_setLabelsDurations: function(key, value){
 			if (key === "durationIn" || key === "durationOut" || key === "delayOut"){
 				if (parseInt(value, 10) !== value) return;
@@ -271,6 +281,7 @@
 		_createHandles: function(){
 			this.leftHandle = this._createHandle({
 					isLeft: true,
+					barHandles: this.options.barHandles,
 					bounds: this.options.bounds,
 					value: this._values.min,
 					step: this.options.step,
@@ -279,6 +290,7 @@
 	
 			this.rightHandle = this._createHandle({
 				isLeft: false,
+				barHandles: this.options.barHandles,
 				bounds: this.options.bounds,
 				value: this._values.max,
 				step: this.options.step,

--- a/jQRangeSliderHandle.js
+++ b/jQRangeSliderHandle.js
@@ -30,10 +30,14 @@
 		_create: function(){
 			$.ui.rangeSliderDraggable.prototype._create.apply(this);
 
+			if (this.options.barHandles){
+				this.element
+					.addClass("ui-rangeSlider-handle")
+			}
+
 			this.element
 				.css("position", "absolute")
 				.css("top", 0)
-				.addClass("ui-rangeSlider-handle")
 				.toggleClass("ui-rangeSlider-leftHandle", this.options.isLeft)
 				.toggleClass("ui-rangeSlider-rightHandle", !this.options.isLeft);
 
@@ -72,6 +76,8 @@
 				this.options.symmetricPositionning = value === true;
 				this.update();
 			}
+
+			this._setBarHandlesOption(key, value);
 
 			$.ui.rangeSliderDraggable.prototype._setOption.apply(this, [key, value]);
 		},
@@ -243,6 +249,16 @@
 			ratio = (position - parentPosition) / availableWidth;
 
 			return	ratio * (max - min) + min;
+		},
+
+		_setBarHandlesOption: function(key, value){
+			if (key === "barHandles" && (value === true || value === false)){
+				this.options.barHandles = value === true;
+				this.update();
+
+				var action = value ? 'addClass' : 'removeClass';
+				this.element[action]("ui-rangeSlider-handle")
+			}
 		},
 
 		/*

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "jQRangeSlider",
   "version": "5.7.1",
   "scripts": {
+    "grunt": "grunt",
     "test": "grunt ci --verbose"
   },
   "devDependencies": {

--- a/tests/unit/tests.js
+++ b/tests/unit/tests.js
@@ -35,7 +35,7 @@ var el = null;
 		},
 		function() {
 			// Default values tests
-			QUnit.deepEqualEpsilon(el.rangeSlider("option", "bounds"), { min:0, max:100 }, 1e-3, "Default bounds should be 0-100");
+			QUnit.deepEqualEpsilon(el.rangeSlider("option", "barHandles"), true, "Default option for bar handles activation");
 			QUnit.deepEqualEpsilon(el.rangeSlider("option", "bounds"), { min:0, max:100 }, 1e-3, "Default bounds should be 0-100");
 			QUnit.deepEqualEpsilon(el.rangeSlider("option", "defaultValues"), {min:20, max:50}, 1e-3, "Default values should be 20-50");
 			QUnit.deepEqual(el.rangeSlider("option", "wheelMode"), null, "Default wheel mode should be empty");
@@ -325,6 +325,20 @@ var arrowsScrollingMouseUpTest = new TestCase(
 	function(){
 		// mouseup on another element than the clicked arrow should stop scrolling
 		QUnit.ok(this.max() !== el.rangeSlider("option", "bounds").max, "mouseup on another element than the clicked arrow should stop scrolling");
+	}
+);
+
+/**
+ *  Bar handles deactivation
+ */
+var noBarHandlesTest = new TestCase(
+	"Bar handles activation property setter",
+	function(){
+		el.rangeSlider("option", "barHandles", false);
+	},
+	function(){
+		var barHandles = el.find(".ui-rangeSlider-handle");
+		QUnit.equal(barHandles.length, 0, "The bar handles should not be accessible in the UI");
 	}
 );
 
@@ -740,6 +754,7 @@ testRunner.add("jQRangeSlider", [setUp,
 			wheelModeZoomTest, wheelModeScrollTest, wheelModeSetterTest, wheelSpeedSetterTest, rangeSetterTest,
 			wheelModeConstructorTest,
 			noArrowsSetterTest, arrowsScrollingMouseUpTest,
+			noBarHandlesTest,
 			defaultSetup,
 			customCtorTest,
 			destroy,


### PR DESCRIPTION
Create a new option to remove the handles in the slider bar so that the drag feature remains available even when having a very small date range. At the moment the handle bar are above so we can't do this.