### PR TITLE
Differentiate left and right labels and merge if identical

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "0.10"
+  - "6"
 before_script:
   - npm update -g npm
   - npm install -g grunt-cli

--- a/jQDateRangeSlider.js
+++ b/jQDateRangeSlider.js
@@ -79,8 +79,8 @@
 			}
 
 			return (function(formatter){
-				return function(value){
-					return formatter(new Date(value));
+				return function(value, isLeft){
+					return formatter(new Date(value), isLeft);
 				};
 			}(formatter));
 		},

--- a/jQRangeSliderBar.js
+++ b/jQRangeSliderBar.js
@@ -10,6 +10,14 @@
 (function($, undefined){
 	"use strict";
 
+	function valueOrFalse(value, defaultValue){
+		if (typeof value === "undefined"){
+			return defaultValue || false;
+		}
+
+		return value;
+	}
+
 	$.widget("ui.rangeSliderBar", $.ui.rangeSliderDraggable, {
 		options: {
 			leftHandle: null,
@@ -541,13 +549,5 @@
 			this._positionBar();
 		}
 	});
-
-	function valueOrFalse(value, defaultValue){
-		if (typeof value === "undefined"){
-			return defaultValue || false;
-		}
-
-		return value;
-	}
 
 }(jQuery));

--- a/jQRangeSliderLabel.js
+++ b/jQRangeSliderLabel.js
@@ -128,7 +128,7 @@
 			if (this.options.formatter === false){
 				this._displayText(Math.round(value));
 			}else{
-				this._displayText(this.options.formatter(value));
+				this._displayText(this.options.formatter(value, this.options.isLeft));
 			}
 
 			this._value = value;

--- a/jQRangeSliderLabel.js
+++ b/jQRangeSliderLabel.js
@@ -8,8 +8,8 @@
  */
 
 (function($, undefined){
-	
-	"use strict";
+	//jshint latedef: nofunc
+	"use strict"; 
 
 	$.widget("ui.rangeSliderLabel", $.ui.rangeSliderMouseTouch, {
 		options: {

--- a/jQRangeSliderLabel.js
+++ b/jQRangeSliderLabel.js
@@ -349,14 +349,18 @@
 			var label1Pos = this.GetRawPosition(this.cache.label1, this.cache.handle1),
 				label2Pos = this.GetRawPosition(this.cache.label2, this.cache.handle2);
 
-			if (this.label1[type]("option", "isLeft")){
-				this.ConstraintPositions(label1Pos, label2Pos);
-			}else{
-				this.ConstraintPositions(label2Pos, label1Pos);
+			if (this.label1[0].innerText === this.label2[0].innerText) {
+				this.PositionLabel(this.label1, (label1Pos.left+label2Pos.left)/2, this.cache.label1);
+				this.PositionLabel(this.label2, (label1Pos.left+label2Pos.left)/2, this.cache.label2);
+			} else {
+				if (this.label1[type]("option", "isLeft")) {
+					this.ConstraintPositions(label1Pos, label2Pos);
+				} else {
+					this.ConstraintPositions(label2Pos, label1Pos);
+				}
+				this.PositionLabel(this.label1, label1Pos.left, this.cache.label1);
+				this.PositionLabel(this.label2, label2Pos.left, this.cache.label2);
 			}
-
-			this.PositionLabel(this.label1, label1Pos.left, this.cache.label1);
-			this.PositionLabel(this.label2, label2Pos.left, this.cache.label2);
 		}
 
 		this.PositionLabel = function(label, leftOffset, cache){

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "grunt-contrib-copy": "^0.5.0",
     "grunt-contrib-cssmin": "^0.10.0",
     "jshint": "^2.5.2",
-    "grunt-contrib-jshint": "^0.10.0",
+    "grunt-contrib-jshint": "^1.1.0",
     "grunt-contrib-connect": "^0.8.0",
     "connect": "^3.1.0",
     "grunt-contrib-uglify": ">= 0.4.x",

--- a/tests/unit/comparison.js
+++ b/tests/unit/comparison.js
@@ -5,7 +5,7 @@
  * Dual licensed under the MIT or GPL Version 2 licenses.
  *
  */
- 
+ //jshint latedef: nofunc
 (function(){
 	"use strict";
 

--- a/tests/unit/editTests.js
+++ b/tests/unit/editTests.js
@@ -62,6 +62,12 @@
 		}
 	);
 
+	function testInputType(type){
+		el.editRangeSlider("option", "type", type);
+		QUnit.equal(el.editRangeSlider("option", "type"), type, "Type option should have been set");
+		QUnit.equal(el.find("input").attr("type"), type, "Type should be used by inputs");
+	}
+
 	var setType = new TestCase(
 		"Input type setter",
 		function(){},
@@ -70,12 +76,6 @@
 			testInputType("number");
 		}
 	);
-
-	function testInputType(type){
-		el.editRangeSlider("option", "type", type);
-		QUnit.equal(el.editRangeSlider("option", "type"), type, "Type option should have been set");
-		QUnit.equal(el.find("input").attr("type"), type, "Type should be used by inputs");
-	}
 
 	var setInvalidType = new TestCase(
 		"Invalid input type",


### PR DESCRIPTION
Enable left and right labels to be formatted differently. E.g. if selecting a month range, the left and right labels are 1 July 2019 to 1 August 2019, but 1 August is not included in the range. This change allows the custom formatter to decrement the right value before generating its label so the labels will be 1 July 2019 to 31 July 2019.

When left and right labels have the same text, position both labels over the centre of the bar so that only one is visible. E.g. when month steps are used this allows the range 1 July 2019-1 August 2019 to be labelled simply July 2019 using a custom formatter.