### PR TITLE
Remove jQuery deprecated methods and fix _setOption function

### DIFF
--- a/jQEditRangeSlider.js
+++ b/jQEditRangeSlider.js
@@ -37,7 +37,7 @@
 				this.options[key] = this.labels.left === null ? value : this._leftLabel("option", key);
 			}
 
-			this._super(label,handle);
+			this._super(key, value);
 		},
 
 		_setLabelOption: function(key, value){
@@ -55,7 +55,7 @@
 			var result = this._super(label,handle);
 			
 			if (label === null){
-				result.bind("valueChange", $.proxy(this._onValueChange, this));
+				result.on("valueChange", $.proxy(this._onValueChange, this));
 			}
 
 			return result;

--- a/jQEditRangeSliderLabel.js
+++ b/jQEditRangeSliderLabel.js
@@ -43,7 +43,7 @@
 
 			this._setInputName();
 
-			this._input.bind("keyup", $.proxy(this._onKeyUp, this));
+			this._input.on("keyup", $.proxy(this._onKeyUp, this));
 			this._input.blur($.proxy(this._onChange, this));
 
 			if (this.options.type === "number"){

--- a/jQRangeSlider.js
+++ b/jQRangeSlider.js
@@ -77,7 +77,7 @@
 				that.resize(e);
 			};
 
-			$(window).resize(this._resizeProxy);
+			$(window).on("resize", this._resizeProxy);
 		},
 
 		_initWidth: function(){
@@ -266,8 +266,8 @@
 
 		_createHandle: function(options){
 			return $("<div />")[this._handleType()](options)
-				.bind("sliderDrag", $.proxy(this._changing, this))
-				.bind("stop", $.proxy(this._changed, this));
+				.on("sliderDrag", $.proxy(this._changing, this))
+				.on("stop", $.proxy(this._changed, this));
 		},
 
 		_createHandles: function(){
@@ -291,8 +291,8 @@
 		_createBar: function(){
 			this.bar = $("<div />")
 				.prependTo(this.container)
-				.bind("sliderDrag scroll zoom", $.proxy(this._changing, this))
-				.bind("stop", $.proxy(this._changed, this));
+				.on("sliderDrag scroll zoom", $.proxy(this._changing, this))
+				.on("stop", $.proxy(this._changed, this));
 			
 			this._bar({
 					leftHandle: this.leftHandle,
@@ -337,7 +337,7 @@
 				target = $.proxy(this._scrollLeftClick, this);
 			}
 
-			arrow.bind("mousedown touchstart", target);
+			arrow.on("mousedown touchstart", target);
 
 			return arrow;
 		},
@@ -601,11 +601,11 @@
 				that._stopScroll();
 			};
 
-			$(document).bind("mouseup touchend", this._stopScrollHandle);
+			$(document).on("mouseup touchend", this._stopScrollHandle);
 		},
 
 		_stopScroll: function(){
-			$(document).unbind("mouseup touchend", this._stopScrollHandle);
+			$(document).off("mouseup touchend", this._stopScrollHandle);
 			this._stopScrollHandle = null;
 			this._bar("stopScroll");
 			clearTimeout(this._scrollTimeout);
@@ -779,7 +779,7 @@
 			this.element.removeClass("ui-rangeSlider");
 			this.options = null;
 
-			$(window).unbind("resize", this._resizeProxy);
+			$(window).off("resize", this._resizeProxy);
 			this._resizeProxy = null;
 			this._bindResize = null;
 

--- a/jQRangeSliderBar.js
+++ b/jQRangeSliderBar.js
@@ -45,14 +45,14 @@
 				.addClass("ui-rangeSlider-bar");
 
 			this.options.leftHandle
-				.bind("initialize", $.proxy(this._onInitialized, this))
-				.bind("mousestart", $.proxy(this._cache, this))
-				.bind("stop", $.proxy(this._onHandleStop, this));
+				.on("initialize", $.proxy(this._onInitialized, this))
+				.on("mousestart", $.proxy(this._cache, this))
+				.on("stop", $.proxy(this._onHandleStop, this));
 
 			this.options.rightHandle
-				.bind("initialize", $.proxy(this._onInitialized, this))
-				.bind("mousestart", $.proxy(this._cache, this))
-				.bind("stop", $.proxy(this._onHandleStop, this));
+				.on("initialize", $.proxy(this._onInitialized, this))
+				.on("mousestart", $.proxy(this._cache, this))
+				.on("stop", $.proxy(this._onHandleStop, this));
 
 			this._bindHandles();
 
@@ -61,8 +61,8 @@
 		},
 
 		destroy: function(){
-			this.options.leftHandle.unbind(".bar");
-			this.options.rightHandle.unbind(".bar");
+			this.options.leftHandle.off(".bar");
+			this.options.rightHandle.off(".bar");
 			this.options = null;
 
 			this._super();
@@ -112,7 +112,7 @@
 		_setWheelModeOption: function(value){
 			if (value === null || value === false || value === "zoom" || value === "scroll"){
 				if (this.options.wheelMode !== value){
-					this.element.parent().unbind("mousewheel.bar");
+					this.element.parent().off("mousewheel.bar");
 				}
 
 				this._bindMouseWheel(value);
@@ -122,9 +122,9 @@
 
 		_bindMouseWheel: function(mode){
 			if (mode === "zoom"){
-				this.element.parent().bind("mousewheel.bar", $.proxy(this._mouseWheelZoom, this));
+				this.element.parent().on("mousewheel.bar", $.proxy(this._mouseWheelZoom, this));
 			}else if (mode === "scroll"){
-				this.element.parent().bind("mousewheel.bar", $.proxy(this._mouseWheelScroll, this));
+				this.element.parent().on("mousewheel.bar", $.proxy(this._mouseWheelScroll, this));
 			}
 		},
 
@@ -338,12 +338,12 @@
 
 		_bindHandles: function(){
 			this.options.leftHandle
-				.unbind(".bar")
-				.bind("sliderDrag.bar update.bar moving.bar", $.proxy(this._onDragLeftHandle, this));
+				.off(".bar")
+				.on("sliderDrag.bar update.bar moving.bar", $.proxy(this._onDragLeftHandle, this));
 
 			this.options.rightHandle
-				.unbind(".bar")
-				.bind("sliderDrag.bar update.bar moving.bar", $.proxy(this._onDragRightHandle, this));
+				.off(".bar")
+				.on("sliderDrag.bar update.bar moving.bar", $.proxy(this._onDragRightHandle, this));
 		},
 
 		_constraintPosition: function(left){
@@ -523,8 +523,8 @@
 					maxValue = Math.max(min, max);
 
 				this._deactivateRange();
-				this.options.leftHandle.unbind(".bar");
-				this.options.rightHandle.unbind(".bar");
+				this.options.leftHandle.off(".bar");
+				this.options.rightHandle.off(".bar");
 
 				this._values.min = this._leftHandle("value", minValue);
 				this._values.max = this._rightHandle("value", maxValue);

--- a/jQRangeSliderLabel.js
+++ b/jQRangeSliderLabel.js
@@ -42,9 +42,9 @@
 			this._toggleClass();
 
 			this.options.handle
-				.bind("moving.label", $.proxy(this._onMoving, this))
-				.bind("update.label", $.proxy(this._onUpdate, this))
-				.bind("switch.label", $.proxy(this._onSwitch, this));
+				.on("moving.label", $.proxy(this._onMoving, this))
+				.on("update.label", $.proxy(this._onUpdate, this))
+				.on("switch.label", $.proxy(this._onSwitch, this));
 
 			if (this.options.show !== "show"){
 				this.element.hide();
@@ -54,7 +54,7 @@
 		},
 
 		destroy: function(){
-			this.options.handle.unbind(".label");
+			this.options.handle.off(".label");
 			this.options.handle = null;
 
 			this._valueContainer = null;
@@ -245,18 +245,18 @@
 
 			this._resizeProxy = $.proxy(this.onWindowResize, this);
 
-			$(window).resize(this._resizeProxy);
+			$(window).on("resize", this._resizeProxy);
 		}
 
 		this.Destroy = function(){
 			if (this._resizeProxy){
-				$(window).unbind("resize", this._resizeProxy);
+				$(window).off("resize", this._resizeProxy);
 				this._resizeProxy = null;
 
-				this.handle1.unbind(".positionner");
+				this.handle1.off(".positionner");
 				this.handle1 = null;
 
-				this.handle2.unbind(".positionner");
+				this.handle2.off(".positionner");
 				this.handle2 = null;
 
 				this.label1 = null;
@@ -333,10 +333,10 @@
 		}
 
 		this.BindHandle = function(handle){
-			handle.bind("updating.positionner", $.proxy(this.onHandleUpdating, this));
-			handle.bind("update.positionner", $.proxy(this.onHandleUpdated, this));
-			handle.bind("moving.positionner", $.proxy(this.onHandleMoving, this));
-			handle.bind("stop.positionner", $.proxy(this.onHandleStop, this));
+			handle.on("updating.positionner", $.proxy(this.onHandleUpdating, this));
+			handle.on("update.positionner", $.proxy(this.onHandleUpdated, this));
+			handle.on("moving.positionner", $.proxy(this.onHandleMoving, this));
+			handle.on("stop.positionner", $.proxy(this.onHandleStop, this));
 		}
 
 		this.PositionLabels = function(){

--- a/jQRangeSliderMouseTouch.js
+++ b/jQRangeSliderMouseTouch.js
@@ -18,15 +18,15 @@
 			this._super();
 			this._mouseDownEvent = false;
 
-			this.element.bind('touchstart.' + this.widgetName, function(event) {
+			this.element.on('touchstart.' + this.widgetName, function(event) {
 				return that._touchStart(event);
 			});
 		},
 
 		_mouseDestroy: function(){
 			$(document)
-				.unbind('touchmove.' + this.widgetName, this._touchMoveDelegate)
-				.unbind('touchend.' + this.widgetName, this._touchEndDelegate);
+				.off('touchmove.' + this.widgetName, this._touchMoveDelegate)
+				.off('touchend.' + this.widgetName, this._touchEndDelegate);
 
 				this._super();
 		},
@@ -71,8 +71,8 @@
 				}
 
 				$(document)
-				.bind('touchmove.' + this.widgetName, this._touchMoveDelegate)
-				.bind('touchend.' + this.widgetName, this._touchEndDelegate);
+				.on('touchmove.' + this.widgetName, this._touchMoveDelegate)
+				.on('touchend.' + this.widgetName, this._touchEndDelegate);
 			}
 		},
 
@@ -87,8 +87,8 @@
 			this._mouseUp(event);
 
 			$(document)
-			.unbind('touchmove.' + this.widgetName, this._touchMoveDelegate)
-			.unbind('touchend.' + this.widgetName, this._touchEndDelegate);
+			.off('touchmove.' + this.widgetName, this._touchMoveDelegate)
+			.off('touchend.' + this.widgetName, this._touchEndDelegate);
 
 		this._mouseDownEvent = false;
 


### PR DESCRIPTION
The jQRangeSlider uses several deprecated jQuery methods:

- bind --> on
- unbind --> off
- resize --> on("resize", ...)

These methods were replaced with the current ones.

It also includes one fix in the method _setOption where the parent class constructor was called with the wrong variables.
this._super(label,handle)  --> 	this._super(key, value);